### PR TITLE
Documentation fix: Event content on version 2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -130,7 +130,7 @@ This was a one-time change to keep it clear and dynamic.
 
 - Prop `pack` removed (async auto import default emojis natives - text)
 - Prop `showCategory` changed to `showCategories`
-- Event content `event.emoji` changed to `emoji.data`
+- Event content `event.emoji` changed to `event.data`
 
 # Structure Emoji
 ![](.emoji.png)


### PR DESCRIPTION
Event content is changed from `event.emoji` to `event.data` in version 2. 
Readme.md states the change is  `event.emoji` to `emoji.data`
